### PR TITLE
add text id relabels

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -156,7 +156,7 @@ namespace "path" {
     from = "request"
     split = 2
     separator = " "
-    match "^/[^a].*" {
+    match "^/(?:[^a]|a[^p]|ap[^i]|api[^/]).*" {
       replacement = "/other"
     }
     match "^/api/system/dbfiles/.*" {
@@ -165,10 +165,10 @@ namespace "path" {
     match "^/api/v1/system/sharp-face/user/.*" {
       replacement = "/api/v1/system/sharp-face/user"
     }
-    match "^/api/master/studio-lessons/.*" {
-      replacement = "/api/master/studio-lessons"
+    match "^/api/master/studio-lessons/(.*?/)?[0-9A-Z]{8,}(?:$|\\?.*$|(/[^?]*).*$)" {
+      replacement = "/api/master/studio-lessons/$1:id$2"
     }
-    match "^/api/queries/[0-9]+/results/.*" {
+    match "^/api/queries/.*" {
       replacement = "/other"
     }
     match "^/api/(.*?)/[0-9]+/[0-9]+/[0-9]+(?:$|\\?.*$|(/[^?]*).*$)" {
@@ -183,8 +183,8 @@ namespace "path" {
     match "^/api/(.*?)/[0-9]+(?:$|\\?.*$|(/[^?]*).*$)" {
       replacement = "/api/$1/:id$2"
     }
-    match "^/api/((?:analysis|bootstrap|campaign|customize|debug|enquete|health|konami|mailer|master|member|oauth|pos|purchase|rena|report|reservation|stock|system|v1/docs|v1/enquete|v1/master|v1/member|v1/messages|v1/pos|v1/purchase|v1/reservation|v1/stock|v1/system|widget|words)[^?]*).*" {
-      replacement = "/api/$1"
+    match "^/api/(analysis|bootstrap|campaign|customize|debug|enquete|health|konami|mailer|master|member|oauth|pos|purchase|rena|report|reservation|stock|system|v1/docs|v1/enquete|v1/master|v1/member|v1/messages|v1/pos|v1/purchase|v1/reservation|v1/stock|v1/system|widget|words)([^?]*).*" {
+      replacement = "/api/$1$2"
     }
     match "^.*" {
       replacement = "/other"

--- a/install.bash
+++ b/install.bash
@@ -156,6 +156,9 @@ namespace "path" {
     from = "request"
     split = 2
     separator = " "
+    match "^/[^a].*" {
+      replacement = "/other"
+    }
     match "^/api/system/dbfiles/.*" {
       replacement = "/api/system/dbfiles"
     }
@@ -166,10 +169,7 @@ namespace "path" {
       replacement = "/api/master/studio-lessons"
     }
     match "^/api/queries/[0-9]+/results/.*" {
-      replacement = "/api/queries/:id/results/:id"
-    }
-    match "^/api/jobs/.*" {
-      replacement = "/api/jobs/:id"
+      replacement = "/other"
     }
     match "^/api/(.*?)/[0-9]+/[0-9]+/[0-9]+(?:$|\\?.*$|(/[^?]*).*$)" {
       replacement = "/api/$1/:id/:id/:id$2"
@@ -183,7 +183,7 @@ namespace "path" {
     match "^/api/(.*?)/[0-9]+(?:$|\\?.*$|(/[^?]*).*$)" {
       replacement = "/api/$1/:id$2"
     }
-    match "^/api/([^?]*).*" {
+    match "^/api/((?:analysis|bootstrap|campaign|customize|debug|enquete|health|konami|mailer|master|member|oauth|pos|purchase|rena|report|reservation|stock|system|v1/docs|v1/enquete|v1/master|v1/member|v1/messages|v1/pos|v1/purchase|v1/reservation|v1/stock|v1/system|widget|words)[^?]*).*" {
       replacement = "/api/$1"
     }
     match "^.*" {

--- a/install.bash
+++ b/install.bash
@@ -162,6 +162,15 @@ namespace "path" {
     match "^/api/v1/system/sharp-face/user/.*" {
       replacement = "/api/v1/system/sharp-face/user"
     }
+    match "^/api/master/studio-lessons/.*" {
+      replacement = "/api/master/studio-lessons"
+    }
+    match "^/api/queries/[0-9]+/results/.*" {
+      replacement = "/api/queries/:id/results/:id"
+    }
+    match "^/api/jobs/.*" {
+      replacement = "/api/jobs/:id"
+    }
     match "^/api/(.*?)/[0-9]+/[0-9]+/[0-9]+(?:$|\\?.*$|(/[^?]*).*$)" {
       replacement = "/api/$1/:id/:id/:id$2"
     }


### PR DESCRIPTION
https://machiiro.atlassian.net/browse/HCREL-9

- パスベースのmetricsで、text形式のidが入ったパスを静的にrelabelする設定を追加します
- こちらは新規構築するサーバーに適用するためのPRとなります
- 既存サーバーへの適用は、install.bashの中の設定ファイル部分のファイルを、s3にアップロードして、Run Commandにて全サーバーに適用する見込みです。

### 確認していただきたい点
- [こちら](https://github.com/hacomono/hacomono-managed-prometheus/commit/f2a981af3e60850fd6d1f9a661feac6f4911a962)のCommitと対応しているため、両者のpathに違いがないか確認をお願いします
  - 参照先のcommitでは:idとなっている部分は、こちらでは `[0-9]+` と読み替えて頂きたく

### 実行したテストケース
- 追加した3パターンに合致するURLをたたき、対応したmetricsが計上されたことを確認
- 既存パターンのURLを叩き、対応したmetricsが計上されたことを確認